### PR TITLE
Add function popKittyDisplay!

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ on top of the stack, execute the following:
 ```julia
 pushKittyDisplay!()
 ```
+
+To stop using KittyTerminalImages, execute the following:
+```julia
+popKittyDisplay!()
+```
+
+This will remove the Kitty image display from the end
+of the display list, if it contains at least one
+other element.
+
 You can also override the general display behaviour so KittyTerminalImages is on top of the stack. This is a hack and can have
 unwanted side effects. To do that, execute the following:
 ```julia

--- a/src/KittyTerminalImages.jl
+++ b/src/KittyTerminalImages.jl
@@ -13,7 +13,7 @@ using PNGFiles
 
 import Base: display
 
-export pushKittyDisplay!, forceKittyDisplay!, set_kitty_config!, get_kitty_config
+export pushKittyDisplay!, forceKittyDisplay!, set_kitty_config!, get_kitty_config, popKittyDisplay!
 
 
 struct KittyDisplay <: AbstractDisplay end
@@ -123,6 +123,14 @@ function pushKittyDisplay!()
     d = Base.Multimedia.displays
     if !isempty(d) && !isa(d[end], KittyDisplay)
         Base.Multimedia.pushdisplay(KittyDisplay())
+    end
+    return
+end
+
+function popKittyDisplay!()
+    d = Base.Multimedia.displays
+    if length(d) > 1 && isa(d[end], KittyDisplay) 
+        _ = Base.Multimedia.popdisplay()
     end
     return
 end

--- a/src/KittyTerminalImages.jl
+++ b/src/KittyTerminalImages.jl
@@ -130,7 +130,7 @@ end
 function popKittyDisplay!()
     d = Base.Multimedia.displays
     if length(d) > 1 && isa(d[end], KittyDisplay) 
-        _ = Base.Multimedia.popdisplay()
+        Base.Multimedia.popdisplay()
     end
     return
 end


### PR DESCRIPTION
To remove the Kitty image display from the end
of the display list, if it contains at least one
other element.

Sometimes I want to stop seeing images in the terminal,
and use external windows instead. 