### PR TITLE
Use weak dependencies instead of Requires.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KittyTerminalImages"
 uuid = "b7fa5abe-5c7d-46c6-a1ae-1026d0d509b9"
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -9,15 +9,20 @@ CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rsvg = "c4c386cf-5103-5370-be45-f3a111cca3b8"
+
+[weakdeps]
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+
+[extensions]
+ComposeExt = "Compose"
 
 [compat]
 Cairo = "1.0.4"
 CodecZlib = "0.7"
+Compose = "0.9.5"
 ImageCore = "0.8, 0.9, 0.10"
 Interpolations = "0.13.2, 0.14, 0.15"
 PNGFiles = "0.3.7, 0.4"
-Requires = "1.0.3"
 Rsvg = "1.0.0"
-julia = "1.4"
+julia = "1.9"

--- a/ext/ComposeExt.jl
+++ b/ext/ComposeExt.jl
@@ -1,6 +1,11 @@
-import .Compose
+module ComposeExt
+
+import Compose
+import KittyTerminalImages: show_custom
 
 # This is necessary as without `false` compose tries to draw a png by themself when calling show
 # instead of writing it to `io`
 show_custom(io::IO, ::MIME"image/png", ctx::Compose.Context) =
     Compose.draw(Compose.PNG(io, Compose.default_graphic_width, Compose.default_graphic_height, false), ctx)
+
+end # module

--- a/src/KittyTerminalImages.jl
+++ b/src/KittyTerminalImages.jl
@@ -7,7 +7,6 @@ import Cairo
 using Base.Multimedia: xdisplayable
 using ImageCore: RGBA, channelview
 using CodecZlib: ZlibCompressor, ZlibCompressorStream
-using Requires: @require
 using Interpolations: interpolate, BSpline, Linear
 using PNGFiles
 
@@ -24,7 +23,6 @@ include("images.jl")
 function __init__()
     # TODO verify that we are actually using kitty
     pushKittyDisplay!()
-    @require Compose="a81c6b42-2e10-5240-aca2-a61377ecd94b" include("integration/Compose.jl")
 end
 
 function draw_temp_file(img)


### PR DESCRIPTION
This PR changes the way that code conditional on another package is loaded from Requires.jl to the [weakdeps](https://pkgdocs.julialang.org/v1/creating-packages/#Weak-dependencies) mechanism.

In addition
- Bumps the min Julia version to `v1.9`
- Bumps the version of this package to `v0.4.0`

